### PR TITLE
Converted 08.062r7 document

### DIFF
--- a/sources/08-062r7/document.adoc
+++ b/sources/08-062r7/document.adoc
@@ -1,5 +1,6 @@
 = OGC Reference Model
 :doctype: other
+:edition: 2.1
 :language: en
 :revdate: 2011-12-19
 :published-date: 2011-12-19

--- a/sources/08-062r7/sections/01-enterprise_view_of_ogc.adoc
+++ b/sources/08-062r7/sections/01-enterprise_view_of_ogc.adoc
@@ -60,7 +60,7 @@ OGC publishes several different types of documents (<<table1>>). Sections 2 and 
 [[table1]]
 .OGC Document Types
 |===
-h| OGC Document Type | Description
+h| OGC Document Type h| Description
 | OpenGIS Implementation Standard | A document containing an OGC consensus, technology dependent standard for application programming interfaces and related standards based on the Abstract Specification or domain-specific extensions to the Abstract Specification. There are five subtypes: Interface, Encoding, Profile, Application Profile, and Application Schema.
 | Abstract Specification | A document (or set of documents) containing an OGC consensus, technology-independent standard for application programming interfaces and related standards based on object-oriented or other IT accepted concepts. It describes and/or models an application environment for interoperable geoprocessing and geospatial data and services products.
 | Best Practices | A document containing discussion related to the use and/or implementation of an adopted OGC document. Best Practices Documents are an official position of the OGC and thus represent an endorsement of the content of the paper.


### PR DESCRIPTION
Notes:
- Unlike other OGC documents, this one doesn't have submission, approval and publication date, rather only "Date". Moreover, editors are not listed. I'm not sure how this should be solved in adoc.
- Warning on the front page has a different content, as well as the License Agreement.
- Caption of the Table 1 is not boldfaced.
- [class=steps] is not working.
- Header and footer in the generated .doc should have a different content.
- Text is not justified in the generated .doc file.
- Years are missing in the quotes.