### PR TITLE
Minor fixes in 17-069r3 sample doc

### DIFF
--- a/sources/17-069r3/document.adoc
+++ b/sources/17-069r3/document.adoc
@@ -1,5 +1,7 @@
 = API - Features - Part 1: Core
-:doctype: other
+:doctype: standard
+:docsubtype: implementation
+:edition: 1.0
 :language: en
 :status: approved
 :committee: technical
@@ -14,7 +16,7 @@
 :role: editor
 :keywords: ogcdoc, OGC document, OGC API, ISO, ISO/TC 211, geographic information, Geospatial API, Web Feature Service, WFS, feature, features, property, geographic information, spatial data, spatial things, dataset, distribution, API, OpenAPI, GeoJSON, GML, HTML, schema.org
 :submitting-organizations: CubeWerx Inc.; Heazeltech LLC; Hexagon; interactive instruments GmbH; Ordnance Survey; Planet Labs; US Army Geospatial Center (AGC)
-:docfile: 17-069r3.adoc
+:docfile: document.adoc
 :mn-document-class: ogc
 :mn-output-extensions: xml,html,doc,pdf,rxl
 :local-cache-only:
@@ -51,4 +53,3 @@ include::sections/91-annexB.adoc[]
 
 include::sections/92-annexC.adoc[]
 
-// include::90-annexD.adoc[]

--- a/sources/17-069r3/sections/04-terms_and_definitions.adoc
+++ b/sources/17-069r3/sections/04-terms_and_definitions.adoc
@@ -24,7 +24,10 @@ a downloadable file, an RSS feed or an API.
 
 === feature
 
-abstraction of real world phenomena [ISO 19101-1:2014]
+abstraction of real world phenomena
+
+[.source]
+<<iso19101,ISO 19101-1:2014>>
 
 NOTE: For those unfamiliar with the term 'feature', the explanations on https://www.w3.org/TR/sdw-bp/#spatial-things-features-and-geometry[Spatial Things, Features and Geometry] in the <<spatial_data_wbp,W3C/OGC Spatial Data on the Web Best Practice document>> provide more detail.
 

--- a/sources/17-069r3/sections/04-terms_and_definitions.adoc
+++ b/sources/17-069r3/sections/04-terms_and_definitions.adoc
@@ -5,15 +5,22 @@ This document uses the terms defined in Sub-clause 5.3 of [OGC 06-121r9], which 
 
 === dataset
 
-collection of data, published or curated by a single agent, and available for access or download in one or more formats <<dcat,[DCAT]>>
+collection of data, published or curated by a single agent, and available for access or download in one or more formats 
+
+[.source]
+<<dcat>>
 
 NOTE: The use of 'collection' in the definition from <<dcat,[DCAT]>> is broader than the use of the term collection in this specification. See the definition of <<term-feature_collection,'feature collection'>>.
 
 === distribution
 
-represents an accessible form of a *dataset* <<dcat,[DCAT]>>
+represents an accessible form of a *dataset* 
 
-EXAMPLE: a downloadable file, an RSS feed or an API.
+[.source]
+<<dcat>>
+
+[example]
+a downloadable file, an RSS feed or an API.
 
 === feature
 
@@ -30,7 +37,10 @@ NOTE: In this specification, 'collection' is used as a synonym for 'feature coll
 
 === Web API
 
-API using an architectural style that is founded on the technologies of the Web <<dwbp,[DWBP]>>
+API using an architectural style that is founded on the technologies of the Web 
+
+[.source]
+<<dwbp,DWBP>>
 
 NOTE: https://www.w3.org/TR/dwbp/#APIHttpVerbs[Best Practice 24: Use Web Standards as the foundation of APIs] in the <<dwbp,W3C Data on the Web Best Practices>> provides more detail.
 

--- a/sources/17-069r3/sections/92-annexC.adoc
+++ b/sources/17-069r3/sections/92-annexC.adoc
@@ -18,3 +18,5 @@
 * [[[dwbp,WBP]]], W3C: *Data on the Web Best Practices,* W3C Recommendation 31 January 2017, https://www.w3.org/TR/dwbp/
 
 * [[[dcat,DCAT]]], W3C: *Data Catalog Vocabulary,* W3C Recommendation 16 January 2014, https://www.w3.org/TR/vocab-dcat/
+
+* [[[iso19101, ISO 19101]]], ISO: *ISO 19101-1:2014 -- Geographic information -- Reference model -- Part 1: Fundamentals* https://www.iso.org/standard/59164.html


### PR DESCRIPTION
Hi @ronaldtse ,

When I was working on standard-implementation OGC template, I noticed some details in 17-069r3 sample doc: http://docs.opengeospatial.org/is/17-069r3/17-069r3.html

- The `doctype` is set to `other` instead of `standard`-`implementation`
-  The references in *Terms and Definitions* are not encoded according to Metanorma documentation: https://www.metanorma.com/author/topics/document-format/section-terms/

So, I took the liberty of fixing these issues and open this PR.

In addition, I noticed that the *Recommendations*, *Requirements*, and *Permissions* are not encoded according to: https://www.metanorma.com/author/ogc/authoring/#recommendations-requirements-and-permissions. But that would be a more laborious work, so I think I shouldn't take action on it without your approval.

Thanks! 
