### PR TITLE
OGC 18-053r2: minor changes in .adoc

### DIFF
--- a/sources/18-053r2/sections/11-declarative_styling_specification.adoc
+++ b/sources/18-053r2/sections/11-declarative_styling_specification.adoc
@@ -1192,7 +1192,7 @@ Returns the base `2` logarithm of `x`.
 [source,ruby]
 ----
 {
-  "show" : "log2(${Density}) > 1.0" +
+  "show" : "log2(${Density}) > 1.0"
 }
 ----
 
@@ -1211,7 +1211,7 @@ Returns the fractional part of `x`. Equivalent to `x - floor(x)`.
 [source,ruby]
 ----
 {
-  "color" : "color() * fract(${Density})" +
+  "color" : "color() * fract(${Density})"
 }
 ----
 
@@ -1436,7 +1436,7 @@ A <<_Point_Cloud,Point Cloud>> is a collection of points that may be styled like
 [source,ruby]
 ----
 {
-  "color" : "color('red')", +
+  "color" : "color('red')",
   "pointSize" : "${Temperature} * 0.5"
 }
 ----

--- a/sources/18-053r2/sections/13-annexB.adoc
+++ b/sources/18-053r2/sections/13-annexB.adoc
@@ -1,7 +1,7 @@
 
 [[annexB]]
 [appendix,obligation=informative]
-== Contributor Acknowledgements (Non-normative)
+== Contributor Acknowledgements
 
 [[Section3]]
 


### PR DESCRIPTION
- Removed unnecessary plus signs.
- Removed "non-informative" from the title in Annex B (it's already marked as informative).