### PR TITLE
Remove user-entered Preface notes

### DIFF
--- a/sources/14-065r2/sections/00-abstract.adoc
+++ b/sources/14-065r2/sections/00-abstract.adoc
@@ -14,10 +14,6 @@ Future work will target the definition of process interfaces for common processe
 
 If OGC baseline and related specifications should further progress towards REST-oriented interfaces, the development of a REST-oriented WPS interface standard should be considered.
 
-Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights.
-
-_Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the standard set forth in this document, and to provide supporting documentation._
-
 
 [abstract]
 == Abstract

--- a/sources/15-104r5/sections/00-preface.adoc
+++ b/sources/15-104r5/sections/00-preface.adoc
@@ -5,10 +5,6 @@ This document specifies the core of an OGC Discrete Global Grid System Abstract 
 
 The intention of this Abstract Specification is to provide the geomatics and decision-making community with a formal document with which DGGS can be recognized, designed, built and used. This Abstract Specification defines the framework components that make up a compliant DGGS and the variability within those components. The value of a DGGS as a spatial reference system is also discussed, as is the opportunity to interoperate between other DGGS and to utilize other OGC/ISO standards within the implementation of DGGS. As with any spatial reference, and especially an approach that is early in adoption, intellectual property rights pertaining to various methods of creating and using DGGS should be expected. For example, there exist multiple patents for indexing DGGS, and the implementers of this Abstract Specification should make themselves aware of these patents.
 
-Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights.
-
-_Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the Abstract Specification set forth in this document, and to provide supporting documentation._
-
 [abstract]
 == Abstract
 

--- a/sources/15-120r5/sections/00-front-material.adoc
+++ b/sources/15-120r5/sections/00-front-material.adoc
@@ -9,9 +9,6 @@ The industry-maintained CDB model and data store structure has been discussed an
 
 At the suggestion of several attendees at the first CDB ad-hoc meeting in September, 2014, the current version of the existing CDB standard was slightly reformatted for consideration as an OGC Best Practice. The OGC Best Practice is the basis of work for this OGC standard.
 
-Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights.
-
-_Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the standard set forth in this document, and to provide supporting documentation._
 
 [abstract]
 == Abstract

--- a/sources/16-114r3/sections/00-preface.adoc
+++ b/sources/16-114r3/sections/00-preface.adoc
@@ -8,9 +8,6 @@ This document does not define any new Moving Features elements, rather it provid
 
 This encoding is intended to provide a faster and more compact alternative to the Moving Features CSV encoding using a format readable by existing software.
 
-Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights.
-
-_Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the standard set forth in this document, and to provide supporting documentation._
 
 [abstract]
 == Abstract

--- a/sources/18-016r1/sections/00-front-material.adoc
+++ b/sources/18-016r1/sections/00-front-material.adoc
@@ -1,10 +1,4 @@
 
-.Preface
-Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights.
-
-_Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the standard set forth in this document, and to provide supporting documentation._
-
-
 [abstract]
 == Abstract
 This document provides release notes for version 1.1 of the CDB Standard and related Best Practices.

--- a/sources/18-046/sections/01-summary.adoc
+++ b/sources/18-046/sections/01-summary.adoc
@@ -67,9 +67,3 @@ h| Name h| Organization
 === Cloud Providers
 
 A special thank you to our CloudSigma, CloudFerro and Amazon for making cloud resources available to the Hackathon!
-
-=== Foreword
-
-Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights.
-
-Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the standard set forth in this document, and to provide supporting documentation.

--- a/sources/19-004/sections/00-preface.adoc
+++ b/sources/19-004/sections/00-preface.adoc
@@ -1,10 +1,4 @@
 
-.Preface
-
-Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights.
-
-Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the standard set forth in this document, and to provide supporting documentation.
-
 [abstract]
 == Abstract
 


### PR DESCRIPTION
From https://github.com/metanorma/mn-samples-ogc/issues/73

Now that the Preface note is generated automatically, there is no need for the user to include it manually.

Thanks!